### PR TITLE
[WIP] Create Marginal class as common return type for inference methods

### DIFF
--- a/primo2/inference/marginal.py
+++ b/primo2/inference/marginal.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Feb 23 13:37:05 2017
+
+@author: jpoeppel
+"""
+
+import numpy as np
+
+class Marginal(object):
+    
+    """
+        A class representing the inference results. This class holds the
+        (joint) probability distribution after performing inference.
+        
+        TODO: Consider adding potentially used evidence and it's probability
+        as well.
+    """
+    
+    def __init__(self):
+        self.variables = []
+        self.values = {}
+        self.probabilities = 0
+        
+    @classmethod
+    def from_factor(cls, factor):
+        """
+            Creates a marginal from a factor. This method should only be used
+            internally as a factor does not make any guarantees about the kind
+            of potential it contains, thus calling it with factors not containing
+            marginal probabilities will result in invalid marginals!
+            
+            Parameters
+            ----------
+            factor: Factor
+                The factor whose potential is used to construct the marginal.
+                
+            Returns
+            --------
+                Marginal
+                The created marginal representing the (joint) posterior
+                marginal over all the variables in the factor.
+        """
+        res = cls()
+        res.variables = factor.variableOrder
+        res.values = dict(factor.values)
+        res.probabilities = factor.potentials.copy()
+        return res
+    
+    def get_probabilities(self, variables=None, returnDict=False):
+        """
+            Returns the probabilities for the specified variable(s), if specified,
+            either as a compact numpy array (default), ordered according to the 
+            variable and corresponding value orders in self.variables and 
+            self.values, or as a dictionary.
+            
+            If variables is not specified it will return the probabilities for
+            all included variables in the specfied form.
+            
+            Parameter
+            ---------
+            variables: dict, string, optional.
+                Dictionary containing the desired variable names as keys and
+                either an instantiation or a list of instantiations of interest 
+                as values. For a marginal containing the binary variables A and B, 
+                get_probabilities({"A":"True"}) and get_probabilities({"A":["True"]})
+                will return the probabilties P(A=True, B=True) and 
+                P(A=True, B=False). Whereas get_probabilities({"A":"True", "B":"False"})
+                will only return P(A=True,B=False).
+                
+            returnDict: Boolean, optional (default: False)
+                Specifies if the probabilities should be returned as a dictionary
+                of the form {variable: probabilities} (if set to true) or as
+                a compact np.array with one dimension for each variable, according
+                to the order given in self.variables. The entries within each
+                dimension correspond to the values specified with the same 
+                indices in self.values for that variable.
+                
+            Returns
+            -------
+                dict or np.array
+                The probabilities for the desired variables and their instantiations.            
+                
+        """
+        
+        
+        
+        if not variables:
+            variables = {}
+        elif isinstance(variables, str):
+            try:
+                variables = {variables: self.values[variables]}
+            except KeyError as e:
+                #TODO Change!
+                raise e
+                
+        if returnDict:
+            #If we want to return dicts, just call this method multiple
+            #times to construct the partial matrizes that we want
+            #TODO This is quite inefficient!!!
+            res = {}            
+            for var in variables:
+                tmp = {}
+                if isinstance(variables[var], str):
+                    variables[var] = [variables[var]]
+                for val in variables[var]:
+                    tmpVariables = dict(variables)
+                    tmpVariables[var] = [val]
+                    tmp[val] = self.get_probabilities(tmpVariables)
+                res[var] = tmp
+            
+            if len(res) == 1:
+                return res.values()[0]
+            return res
+            
+        index = []        
+        for v in self.variables:
+            if v in variables:
+                try:
+                    if isinstance(variables[v], str):
+                        #In case we simply have a string, add only that index
+                        index.append([self.values[v].index(variables[v])])
+                    elif len(variables[v]) == 0:
+#                        If we have an empty list, we use the entire slice
+                        index.append(range(len(self.values[v])))
+                    else:
+                        #Otherwise we just take the indices of interest
+                        index.append([self.values[v].index(value) for value in variables[v]])
+                except ValueError:
+                    raise ValueError("There is no potential for variable {} with values {} in this factor.".format(v, variables[v]))
+            else:
+                index.append(range(len(self.values[v])))
+                    
+        
+            
+        res = np.squeeze(np.copy(self.probabilities[np.ix_(*index)]))
+            
+        return res

--- a/primo2/tests/Marginal_test.py
+++ b/primo2/tests/Marginal_test.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Feb 23 14:09:48 2017
+
+@author: jpoeppel
+"""
+
+import unittest
+
+import numpy as np
+
+import random
+
+from primo2.inference.factor import Factor
+from primo2.inference.marginal import Marginal
+
+class MarginalTest(unittest.TestCase):
+    
+    def __init__(self, methodName, testFactor=None):
+        super(MarginalTest, self).__init__(methodName)
+        self.factor = testFactor      
+    
+    def test_create_from_factor(self):
+        m = Marginal.from_factor(self.factor)
+        
+        self.assertEqual(m.variables, self.factor.variableOrder)
+        for v in self.factor.values:
+            self.assertEqual(m.values[v], self.factor.values[v])
+        np.testing.assert_array_equal(m.probabilities, self.factor.potentials)
+        pass
+    
+    def test_get_probabilities_entire_variable_str_dict(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        res = m.get_probabilities(varName, returnDict=True)
+        self.assertIsInstance(res, dict)
+        for k in res:
+#            self.assertEqual(res[k], self.factor.potentials[self.factor.values[varName].index(k)])
+            np.testing.assert_array_equal(res[k], self.factor.potentials[self.factor.values[varName].index(k)])
+        pass
+    
+    def test_get_probabilities_entire_variable_str_array(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        res = m.get_probabilities(varName, returnDict=False)
+        self.assertIsInstance(res, np.ndarray)
+        np.testing.assert_array_equal(res, self.factor.potentials)
+        
+    def test_get_probabilities_entire_variable_list_dict(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        res = m.get_probabilities({varName: self.factor.values[varName]}, returnDict=True)
+        self.assertIsInstance(res, dict)
+        for k in res:
+            np.testing.assert_array_equal(res[k], self.factor.potentials[self.factor.values[varName].index(k)])
+    
+    def test_get_probabilities_entire_variable_list_array(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        res = m.get_probabilities({varName: self.factor.values[varName]}, returnDict=False)
+        self.assertIsInstance(res, np.ndarray)
+        np.testing.assert_array_equal(res, self.factor.potentials)
+        
+    def test_get_probabilities_entire_variable_empty_list_array(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        res = m.get_probabilities({varName: []}, returnDict=False)
+        self.assertIsInstance(res, np.ndarray)
+        np.testing.assert_array_equal(res, self.factor.potentials)
+        
+    def test_get_probabilities_entire_variable_empty_list_dict(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        res = m.get_probabilities({varName: []}, returnDict=True)
+        self.assertIsInstance(res, dict)
+        for k in res:
+            np.testing.assert_array_equal(res[k], self.factor.get_potential({varName: [k]}))
+#            self.assertEqual(res[k], self.factor.get_potential({varName: [value]}))
+    
+    def test_get_probabilities_part_variable_list_dict(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        value = random.choice(self.factor.values[varName])
+        res = m.get_probabilities({varName: [value]}, returnDict=True)
+        self.assertIsInstance(res, dict)
+        for k in res:
+            np.testing.assert_array_equal(res[k], self.factor.get_potential({varName: [k]}))
+    
+    def test_get_probabilities_part_variable_list_array(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        value = random.choice(self.factor.values[varName])
+        res = m.get_probabilities({varName: [value]}, returnDict=False)
+        self.assertIsInstance(res, np.ndarray)
+        np.testing.assert_array_equal(res, self.factor.get_potential({varName: [value]}))
+        
+    def test_get_probabilities_part_variable_str_dict(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        value = random.choice(self.factor.values[varName])
+        res = m.get_probabilities({varName: value}, returnDict=True)
+        self.assertIsInstance(res, dict)
+        for k in res:
+            np.testing.assert_array_equal(res[k], self.factor.get_potential({varName: [k]}))
+    
+    def test_get_probabilities_part_variable_str_array(self):
+        m = Marginal.from_factor(self.factor)
+        varName = self.factor.checkVar
+        value = random.choice(self.factor.values[varName])
+        res = m.get_probabilities({varName: value}, returnDict=False)
+        self.assertIsInstance(res, np.ndarray)
+        np.testing.assert_array_equal(res, self.factor.get_potential({varName: [value]}))
+    
+    def test_get_probabilitites_unknown_variable(self):
+        m = Marginal.from_factor(self.factor)
+        wrongVar = self.factor.wrongVar
+        with self.assertRaises(ValueError) as cm:
+            m.get_probabilitites(wrongVar)
+        self.assertEqual(str(cm.exception), "This marginal does not contain the variable '{}'.".format(wrongVar))
+            
+    
+    def test_get_probability_simple(self):
+        pass
+    
+    def test_get_probability_under_specified(self):
+        pass
+    
+    def test_get_probability_fully_specified(self):
+        pass
+    
+    def test_marginalize(self):
+        pass
+    
+    def test_marginalize_missing(self):
+        pass
+    
+    
+def setUp_test_factors():
+    f = Factor()
+    f.variableOrder = ["A"]
+    f.values = {"A": ["True","False"]}
+    f.variables = {"A":0}
+    f.potentials = np.array([0.2,0.8])
+    f.checkVar = "A"
+    f.wrongVar = "B"
+    
+    f2 = Factor()
+    f2.variableOrder = ["A", "B"]
+    f2.values = {"A": ["1","2","3"], "B":["Apples", "Peaches"]}
+    f2.variables = {"A":0, "B":1}
+    f2.potentials = np.array([[0.2,0.1], [0.15,0.05], [0.27,0.23]])
+    f2.checkVar = "A"
+    f2.wrongVar = "C"
+    return [f,f2]
+    
+def load_tests(loader, tests, pattern):
+    test_cases = unittest.TestSuite()
+    for f in setUp_test_factors():
+        test_cases.addTest(MarginalTest("test_create_from_factor", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_entire_variable_str_dict", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_entire_variable_str_array", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_entire_variable_list_dict", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_entire_variable_list_array", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_entire_variable_empty_list_array", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_entire_variable_empty_list_dict", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_part_variable_list_dict", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_part_variable_list_array", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_part_variable_str_dict", f))
+        test_cases.addTest(MarginalTest("test_get_probabilities_part_variable_list_dict", f))
+        
+#        test_cases.addTest(MarginalTest("test_get_probabilitites_unknown_variable", f))
+#        test_cases.addTest(MarginalTest("test_get_probability_simple", f))
+#        test_cases.addTest(MarginalTest("test_get_probability_under_specified", f))
+#        test_cases.addTest(MarginalTest("test_get_probability_fully_specified", f))
+#        test_cases.addTest(MarginalTest("test_marginalize", f))
+#        test_cases.addTest(MarginalTest("test_marginalize_missing", f))
+    return test_cases
+    
+    
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a work in progress. So far I've started creating fundamental tests for the different use cases that we have considered. They still need to be expanded upon with more complex marginals as well as other convenience functions. 
The reason I am already opening the PR is to discuss the proposed interface, which is already quite flexible, but I am not too sure about the dictionary return yet. 

Currently I handle a request like `m.get_probabilities({"A":["True","False"]}, returnDict=True})` for a marginal containing the binary variables A and B like so:

`{"True": np.array([P(A=True, B=True), P(A=True, B=False)]), "False": np.array([P(A=False, B=True), P(A=False, B=False)])}.`


A request such as:  `m.get_probabilities({"A":["True", "False"], "B": "False"}, returnDict=True})` [note that you do not have to insert single instantiations in lists, but can just specify them as values directly] yields:

`{A: {"True": np.array([P(A=True, B=False)]), "False":np.array(P(A=False,B=False))}, B: {"False": np.array([P(A=True,B=False)])}}`

since the request desires the probability for this combination. When returnDict=False this method basically behaves as Factor.get_potential with the additional convencience of not having to specify single instantiations in lists as well as allowing things like "get_probabilities("A")".
