### PR TITLE
Added support for properties as meta-data

### DIFF
--- a/primo2/io.py
+++ b/primo2/io.py
@@ -31,6 +31,25 @@ class XMLBIFParser(object):
         
     @staticmethod
     def parse(filename, ignoreProperties=True):
+        """
+            Static parsing method for xbif files.
+            
+            Parameters
+            ----------
+            filename: String
+                Path of the xbif file to be loaded.
+                
+            ignoreProperties: Boolean (optional)
+                If given, will ignore any PROPERTY tags in the xbif file, 
+                otherwise those elements will be stored in a meta attribute
+                either on the network class or the variable node, depending
+                on the nesting of the PROPERTY-tag. Default: True
+            
+            Returns
+            -------
+                BayesianNetwork
+                The parsed network from the xbif file.
+        """
         bn = networks.BayesianNetwork()
 
         tree = et.parse(filename)
@@ -72,6 +91,22 @@ class XMLBIFParser(object):
         
     @staticmethod
     def write(bn, filename, ignoreProperties=False):
+        """
+            Static writing method for xbif files.
+            
+            Parameters
+            ----------
+            filename: String
+                Path of the xbif file to be written.
+                
+            ignoreProperties: Boolean (optional)
+                If given, any meta information in either the network or the
+                variable nodes will not be written to the xbif file, 
+                otherwise a PROPERTY-tag will be created for each element in
+                the meta attribute, nested either directly below the network 
+                (for network meta data) or the corresponding variable (for
+                variable meta data). Default: True
+        """
         root = et.Element("BIF")
         root.attrib["VERSION"] = "0.3"
         network = et.SubElement(root, "NETWORK")

--- a/primo2/networks.py
+++ b/primo2/networks.py
@@ -31,6 +31,7 @@ class BayesianNetwork(object):
         self.graph = nx.DiGraph()
         self.node_lookup = {}
         self.name = "" #Only used to be compatible with XMLBIF
+        self.meta = [] #Used to be compatible with XMLBIF, stores properties 
 
     def add_node(self, node):
         if isinstance(node, nodes.RandomNode):

--- a/primo2/nodes.py
+++ b/primo2/nodes.py
@@ -34,6 +34,7 @@ class RandomNode(object):
     def __init__(self, nodename):
         self.name = nodename
         self.cpd = 1
+        self.meta = []
         
     def set_cpd(self, cpd):
         raise NotImplementedError("Called unimplemented method.")

--- a/primo2/tests/IO_test.py
+++ b/primo2/tests/IO_test.py
@@ -19,7 +19,7 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-
+import os
 import unittest
 import numpy as np
 
@@ -66,6 +66,44 @@ class XMLBIFTest(unittest.TestCase):
         cpt = np.array([[[0.8,0.5,0.7],[0.6,0.2,0.1]],[[0.2,0.5,0.3],[0.4,0.8,0.9]]])
         np.testing.assert_array_almost_equal(johnNode.cpd, cpt)
         
+    def test_readXMLBIF_with_variable_properties(self):
+        bn = XMLBIFParser.parse("primo2/tests/testfile.xbif", ignoreProperties=False)
+        
+        johnNode = bn.get_node("John_calls")
+        self.assertEqual(len(johnNode.meta), 1)
+        self.assertTrue("position" in johnNode.meta[0])
+        
+        alarmNode = bn.get_node("Alarm")
+        
+        self.assertEqual(len(alarmNode.meta), 2)
+        self.assertTrue("position" in alarmNode.meta[0])
+        self.assertEqual("Random meta test", alarmNode.meta[1])
+        
+    def test_readXMLBIF_with_variable_properties_ignored(self):
+        bn = XMLBIFParser.parse("primo2/tests/testfile.xbif", ignoreProperties=True)
+        johnNode = bn.get_node("John_calls")
+        self.assertEqual(len(johnNode.meta), 0)
+        
+        alarmNode = bn.get_node("Alarm")
+        self.assertEqual(len(alarmNode.meta), 0)
+        
+    def test_readXMLBIF_with_network_properties(self):
+        bn = XMLBIFParser.parse("primo2/tests/testfile.xbif", ignoreProperties=False)
+        
+        self.assertEqual(len(bn.meta), 2)
+        self.assertEqual("Random network property", bn.meta[0])
+        self.assertEqual("Author jpoeppel", bn.meta[1])
+        
+        bn = XMLBIFParser.parse("primo2/tests/slippery.xbif", ignoreProperties=False)
+        self.assertEqual(len(bn.meta), 0)
+        
+    def test_readXMLBIF_with_network_properties_ignored(self):
+        bn = XMLBIFParser.parse("primo2/tests/testfile.xbif", ignoreProperties=True)
+        self.assertEqual(len(bn.meta), 0)
+        
+        
+        
+        
     def test_writeXMLBIF_simple(self):
         path= "primo2/tests/test.xbif"
         bn = BayesianNetwork()
@@ -104,9 +142,57 @@ class XMLBIFTest(unittest.TestCase):
         import os
         os.remove(testPath)
         
+    def test_writeXMLBIF_with_network_properties_ignored(self):
+        testPath = "primo2/tests/testSlippery.xbif"
+        bn = XMLBIFParser.parse("primo2/tests/slippery.xbif")
+        bn.meta = ["Dummy property"]
+        XMLBIFParser.write(bn, testPath, ignoreProperties=True)
+        bn2 = XMLBIFParser.parse(testPath, ignoreProperties=False)
+        self.assertEqual(len(bn2.meta),0)
+        self.assertEqual("Dummy property", bn.meta[0])
+        os.remove(testPath)
+        
+    def test_writeXMLBIF_with_network_properties(self):
+        testPath = "primo2/tests/testSlippery.xbif"
+        bn = XMLBIFParser.parse("primo2/tests/slippery.xbif")
+        bn.meta = ["Dummy property"]
+        XMLBIFParser.write(bn, testPath, ignoreProperties=False)
+        bn2 = XMLBIFParser.parse(testPath, ignoreProperties=False)
+        self.assertEqual(len(bn2.meta),1)
+        self.assertEqual("Dummy property", bn.meta[0])
+        os.remove(testPath)
+        
+    def test_writeXMLBIF_with_variable_properties_ignored(self):
+        testPath = "primo2/tests/test_testfile.xbif"
+        bn = XMLBIFParser.parse("primo2/tests/testfile.xbif", ignoreProperties=False)
+        XMLBIFParser.write(bn, testPath, ignoreProperties=True)
+        bn2 = XMLBIFParser.parse(testPath, ignoreProperties=False)
+        johnNode = bn2.get_node("John_calls")
+        self.assertEqual(len(johnNode.meta), 0)
+        
+        alarmNode = bn2.get_node("Alarm")
+        self.assertEqual(len(alarmNode.meta), 0)
+        os.remove(testPath)
+    
+    def test_writeXMLBIF_with_variable_properties(self):
+        testPath = "primo2/tests/test_testfile.xbif"
+        bn = XMLBIFParser.parse("primo2/tests/testfile.xbif", ignoreProperties=False)
+        XMLBIFParser.write(bn, testPath, ignoreProperties=False)
+        bn2 = XMLBIFParser.parse(testPath, ignoreProperties=False)
+        johnNode = bn2.get_node("John_calls")
+        self.assertEqual(len(johnNode.meta), 1)
+        self.assertTrue("position" in johnNode.meta[0])
+        
+        alarmNode = bn2.get_node("Alarm")
+        
+        self.assertEqual(len(alarmNode.meta), 2)
+        self.assertTrue("position" in alarmNode.meta[0])
+        self.assertEqual("Random meta test", alarmNode.meta[1])
+        os.remove(testPath)
+        
 if __name__ == "__main__":
     #Workaround so that this script also finds the resource files when run directly
     # from within the tests folder
-    import os
+    
     os.chdir("../..")
     unittest.main()

--- a/primo2/tests/Inverence_test.py
+++ b/primo2/tests/Inverence_test.py
@@ -188,6 +188,11 @@ class FactorEliminationTest(unittest.TestCase):
         resFactor = ft.marginals(["slippery_road"])
         np.testing.assert_array_almost_equal(resFactor.get_potential(), np.array([0.364, 0.636]))
         
+    def test_jointree_marginals3(self):
+        ft = FactorTree.create_jointree(self.bn)
+        resFactor = ft.marginals(["sprinkler"])
+        np.testing.assert_array_almost_equal(resFactor.get_potential(), np.array([0.42, 0.58]))
+        
     def test_jointree_marginals_trivial_evidence(self):
         ft = FactorTree.create_jointree(self.bn)
         ft.set_evidence({"slippery_road":"true"})

--- a/primo2/tests/testfile.xbif
+++ b/primo2/tests/testfile.xbif
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
     <BIF VERSION="0.3">
         <NETWORK>
+            <PROPERTY>Random network property</PROPERTY>
+            <PROPERTY>Author jpoeppel</PROPERTY>
             <NAME>Test Net</NAME>
             <VARIABLE TYPE="nature">
                 <NAME>Burglary</NAME>
@@ -14,6 +16,7 @@
                 <OUTCOME>Silent</OUTCOME>
                 <OUTCOME>Kaputt</OUTCOME>
                 <PROPERTY>position = (300, 100)</PROPERTY>
+                <PROPERTY>Random meta test</PROPERTY>
             </VARIABLE>
             <VARIABLE TYPE="nature">
                 <NAME>John_calls</NAME>


### PR DESCRIPTION
XBIF supports the PROPERTY tag for meta-data on the network, the variable, and the definition level. These changes add an optional flag to the io-methods parse/write called ignoreProperties, which will ignore those fields by default (old behaviour) but which can be set to False, which will result in the properties for the network and for the variables to be stored in a new "meta" attribute. When writing these fields will again be ignored unless otherwise specified.

Since the PROPERTY tag has no structure, we are only storing the plain strings in a list in the meta attributes.