### PR TITLE
Allow relativ loading of dbn networks from conf

### DIFF
--- a/primo2/io.py
+++ b/primo2/io.py
@@ -180,9 +180,16 @@ class DBNSpec(object):
         with open(filename) as json_data:
             spec = json.load(json_data)
             
+        
         basepath = os.path.dirname(os.path.abspath(filename))
-        b0 = XMLBIFParser.parse(basepath + os.path.sep + spec['B0'])
-        two_tbn = XMLBIFParser.parse(basepath + os.path.sep + spec['TBN'])
+        if os.path.isabs(spec['B0']):
+            b0 = XMLBIFParser.parse(spec['B0'])
+        else:
+            b0 = XMLBIFParser.parse(basepath + os.path.sep + spec['B0'])
+        if os.path.isabs(spec['TBN']):
+            two_tbn = XMLBIFParser.parse(spec['TBN'])
+        else:
+            two_tbn = XMLBIFParser.parse(basepath + os.path.sep + spec['TBN'])
         dbn = networks.DynamicBayesianNetwork(b0, two_tbn)
         for transition in spec['transitions']:
             dbn.add_transition(transition[0], transition[1])

--- a/primo2/networks.py
+++ b/primo2/networks.py
@@ -69,7 +69,20 @@ class BayesianNetwork(object):
             return self.node_lookup[node_name]
         except KeyError:
             raise Exception("There is no node with name {} in the BayesianNetwork".format(node_name))
-
+            
+    def change_node_values(self, node, newValues):
+        """
+            Updates the values of the given node. This will invalidate the node
+            and all it's children, as those nodes will expect new CPTs to match
+            the new values!
+        """
+        if node in self.node_lookup:
+            self.node_lookup[node].set_values(newValues)
+            for child in self.graph.succ[node]:
+                child._update_dimensions()
+        else:
+            raise Exception("There is no node with name {} in the network.".format(node))
+            
     def get_all_nodes(self):
         return self.graph.nodes()
         

--- a/primo2/tests/IO_test.py
+++ b/primo2/tests/IO_test.py
@@ -204,24 +204,37 @@ class DBNSpecTest(unittest.TestCase):
         self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
         os.chdir("../..")
         
-    def test_parseDBN_absolute_path(self):
+    def test_parseDBN_relative(self):
         import shutil
+        shutil.copyfile("primo2/tests/dbn-test-b0.xbif", "primo2/dbn-test-b0.xbif")
+        shutil.copyfile("primo2/tests/dbn-test-2tbn.xbif", "primo2/dbn-test-2tbn.xbif")
+        dbn = DBNSpec.parse("primo2/tests/dbn-test-relative.conf")
+        self.assertEqual(dbn._b0.name, "Test_DBN_B0")
+        self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
+        #Clean up
+        os.remove("primo2/dbn-test-b0.xbif")
+        os.remove("primo2/dbn-test-2tbn.xbif")
+        
+    def test_parseDBN_absolute_path(self):
         if os.path.exists("/tmp"):
+            import shutil
             shutil.copyfile("primo2/tests/dbn-test-b0.xbif", "/tmp/dbn-test-b0.xbif")
             shutil.copyfile("primo2/tests/dbn-test-2tbn.xbif", "/tmp/dbn-test-2tbn.xbif")
             dbn = DBNSpec.parse("primo2/tests/dbn-test-abs.conf")
             self.assertEqual(dbn._b0.name, "Test_DBN_B0")
             self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
+            #Clean up
             os.remove("/tmp/dbn-test-b0.xbif")
             os.remove("/tmp/dbn-test-2tbn.xbif")
             
     def test_parseDBN_mixed_path(self):
-        import shutil
         if os.path.exists("/tmp"):
+            import shutil
             shutil.copyfile("primo2/tests/dbn-test-b0.xbif", "/tmp/dbn-test-b0.xbif")
             dbn = DBNSpec.parse("primo2/tests/dbn-test-mixed.conf")
             self.assertEqual(dbn._b0.name, "Test_DBN_B0")
             self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
+            #Clean up
             os.remove("/tmp/dbn-test-b0.xbif")
     
 if __name__ == "__main__":

--- a/primo2/tests/IO_test.py
+++ b/primo2/tests/IO_test.py
@@ -203,6 +203,26 @@ class DBNSpecTest(unittest.TestCase):
         self.assertEqual(dbn._b0.name, "Test_DBN_B0")
         self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
         os.chdir("../..")
+        
+    def test_parseDBN_absolute_path(self):
+        import shutil
+        if os.path.exists("/tmp"):
+            shutil.copyfile("primo2/tests/dbn-test-b0.xbif", "/tmp/dbn-test-b0.xbif")
+            shutil.copyfile("primo2/tests/dbn-test-2tbn.xbif", "/tmp/dbn-test-2tbn.xbif")
+            dbn = DBNSpec.parse("primo2/tests/dbn-test-abs.conf")
+            self.assertEqual(dbn._b0.name, "Test_DBN_B0")
+            self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
+            os.remove("/tmp/dbn-test-b0.xbif")
+            os.remove("/tmp/dbn-test-2tbn.xbif")
+            
+    def test_parseDBN_mixed_path(self):
+        import shutil
+        if os.path.exists("/tmp"):
+            shutil.copyfile("primo2/tests/dbn-test-b0.xbif", "/tmp/dbn-test-b0.xbif")
+            dbn = DBNSpec.parse("primo2/tests/dbn-test-mixed.conf")
+            self.assertEqual(dbn._b0.name, "Test_DBN_B0")
+            self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
+            os.remove("/tmp/dbn-test-b0.xbif")
     
 if __name__ == "__main__":
     #Workaround so that this script also finds the resource files when run directly

--- a/primo2/tests/dbn-test-2tbn.xbif
+++ b/primo2/tests/dbn-test-2tbn.xbif
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+
+<!--
+  Bayesian network in XMLBIF v0.3 (BayesNet Interchange Format)
+  Produced by SamIam http://reasoning.cs.ucla.edu/samiam
+  Output created Feb 13, 2017 4:29:38 PM
+-->
+
+<BIF VERSION="0.3">
+<NETWORK>
+  <NAME>Test_DBN_2TBN</NAME>
+
+  <VARIABLE TYPE="nature">
+    <NAME>A</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (300, 0)</PROPERTY>
+  </VARIABLE>
+
+  <VARIABLE TYPE="nature">
+    <NAME>B</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (400, 0)</PROPERTY>
+  </VARIABLE>
+
+  <VARIABLE TYPE="nature">
+    <NAME>B_t0</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (400, 0)</PROPERTY>
+  </VARIABLE>
+
+  <VARIABLE TYPE="nature">
+    <NAME>C</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (300, 0)</PROPERTY>
+  </VARIABLE>
+
+  <VARIABLE TYPE="nature">
+    <NAME>C_t0</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (300, 0)</PROPERTY>
+  </VARIABLE>
+
+  <DEFINITION>
+    <FOR>A</FOR>
+    <GIVEN>B_t0</GIVEN>
+    <GIVEN>C_t0</GIVEN>
+    <TABLE>0.8 0.2 0.6 0.4 0.65 0.25 0.5 0.5 </TABLE>
+  </DEFINITION>
+
+  <DEFINITION>
+    <FOR>B</FOR>
+    <GIVEN>B_t0</GIVEN>
+    <GIVEN>A</GIVEN>
+    <TABLE>0.2 0.8 0.3 0.7 0.4 0.6 0.75 0.25</TABLE>
+  </DEFINITION>
+
+  <DEFINITION>
+    <FOR>B_t0</FOR>
+    <TABLE>0.5 0.5 </TABLE>
+  </DEFINITION>
+
+  <DEFINITION>
+    <FOR>C</FOR>
+    <GIVEN>C_t0</GIVEN>
+    <TABLE>0.7 0.3 0.45 0.55</TABLE>
+  </DEFINITION>
+
+  <DEFINITION>
+    <FOR>C_t0</FOR>
+    <TABLE>0.1 0.9 </TABLE>
+  </DEFINITION>  
+
+</NETWORK>
+</BIF>

--- a/primo2/tests/dbn-test-abs.conf
+++ b/primo2/tests/dbn-test-abs.conf
@@ -1,0 +1,8 @@
+{
+	"B0": "/tmp/dbn-test-b0.xbif",
+	"TBN": "/tmp/dbn-test-2tbn.xbif",
+	"transitions": [
+		["C_t0", "C"],
+		["B_t0", "B"]
+	]
+}

--- a/primo2/tests/dbn-test-b0.xbif
+++ b/primo2/tests/dbn-test-b0.xbif
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+
+<!--
+  Bayesian network in XMLBIF v0.3 (BayesNet Interchange Format)
+  Produced by SamIam http://reasoning.cs.ucla.edu/samiam
+  Output created Feb 13, 2017 4:29:38 PM
+-->
+
+<BIF VERSION="0.3">
+<NETWORK>
+  <NAME>Test_DBN_B0</NAME>
+
+  <VARIABLE TYPE="nature">
+    <NAME>A</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (300, 0)</PROPERTY>
+  </VARIABLE>
+
+  <VARIABLE TYPE="nature">
+    <NAME>B</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (400, 0)</PROPERTY>
+  </VARIABLE>
+
+  <VARIABLE TYPE="nature">
+    <NAME>C</NAME>
+    <OUTCOME>True</OUTCOME>
+    <OUTCOME>False</OUTCOME>
+    <PROPERTY>position = (300, 0)</PROPERTY>
+  </VARIABLE>
+
+
+  <DEFINITION>
+    <FOR>B</FOR>
+    <TABLE>0.5 0.5 </TABLE>
+  </DEFINITION>
+
+  <DEFINITION>
+    <FOR>C</FOR>
+    <TABLE>0.2 0.8 </TABLE>
+  </DEFINITION>
+
+</NETWORK>
+</BIF>

--- a/primo2/tests/dbn-test-mixed.conf
+++ b/primo2/tests/dbn-test-mixed.conf
@@ -1,0 +1,8 @@
+{
+	"B0": "/tmp/dbn-test-b0.xbif",
+	"TBN": "dbn-test-2tbn.xbif",
+	"transitions": [
+		["C_t0", "C"],
+		["B_t0", "B"]
+	]
+}

--- a/primo2/tests/dbn-test-relative.conf
+++ b/primo2/tests/dbn-test-relative.conf
@@ -1,0 +1,8 @@
+{
+	"B0": "../dbn-test-b0.xbif",
+	"TBN": "../dbn-test-2tbn.xbif",
+	"transitions": [
+		["C_t0", "C"],
+		["B_t0", "B"]
+	]
+}

--- a/primo2/tests/dbn-test.conf
+++ b/primo2/tests/dbn-test.conf
@@ -1,0 +1,8 @@
+{
+	"B0": "dbn-test-b0.xbif",
+	"TBN": "dbn-test-2tbn.xbif",
+	"transitions": [
+		["C_t0", "C"],
+		["B_t0", "B"]
+	]
+}


### PR DESCRIPTION
DBNSpec currently assumes that the network xbif-files for b0 and 2tbn are located in the working directory. This fix will always search for those files relative to the directory of the conf-file.