### PR TITLE
Changing values of nodes

### DIFF
--- a/primo2/networks.py
+++ b/primo2/networks.py
@@ -83,15 +83,6 @@ class BayesianNetwork(object):
         else:
             raise Exception("There is no node with name {} in the network.".format(node))
             
-    def change_node_name(self, oldName, newName):
-        """
-            Renames the given node to the new name. 
-            Will have to modify all occurances of the old name.
-        """
-        if oldName in self.node_lookup:
-            pass
-        else:
-            raise Exception("There is no node with name {} in the network.".format(oldName))
 
     def get_all_nodes(self):
         return self.graph.nodes()

--- a/primo2/networks.py
+++ b/primo2/networks.py
@@ -70,14 +70,21 @@ class BayesianNetwork(object):
         except KeyError:
             raise Exception("There is no node with name {} in the BayesianNetwork".format(node_name))
             
-    def change_node_values(self, node, newValues):
+    def change_node_values(self, node, new_values):
         """
             Updates the values of the given node. This will invalidate the node
             and all it's children, as those nodes will expect new CPTs to match
             the new values!
+            
+            Parameters
+            ---------
+            node: String or RandomNode
+                The node whose values should be changed.
+            new_values: [String,]
+                List of the new value names.
         """
         if node in self.node_lookup:
-            self.node_lookup[node].set_values(newValues)
+            self.node_lookup[node].set_values(new_values)
             for child in self.graph.succ[node]:
                 child._update_dimensions()
         else:

--- a/primo2/nodes.py
+++ b/primo2/nodes.py
@@ -107,7 +107,7 @@ class DiscreteNode(RandomNode):
         self.parentOrder.append(parentNode.name)
         self._update_dimensions()
         
-    def set_values(self, newValues):
+    def set_values(self, new_values):
         """
             Allows to change/set the values of this variable. This will 
             invalidate the node, as it is expected to receive a new cpt 
@@ -120,10 +120,10 @@ class DiscreteNode(RandomNode):
             
             Parameters
             ----------
-            newValues: [String,]
+            new_values: [String,]
                 List of the new value names.
         """
-        self.values = list(newValues)
+        self.values = list(new_values)
         self._update_dimensions()        
         
         


### PR DESCRIPTION
This PR adds the function "set_values" to the DiscreteNode class as well as "change_node_values" to the BayesianNetwork class. The former updates the values of a node, updating the dimensions of it's cpt and invalidating it in the process as one cannot assume that the old cpt is still valid. The latter does the same, but will also update the dimensions and invalidates all children of the changed node and should be preferred in general.