### PR TITLE
Change node name

### DIFF
--- a/primo2/io.py
+++ b/primo2/io.py
@@ -20,6 +20,7 @@
 # <http://www.gnu.org/licenses/>.
 
 import json
+import os
 
 import lxml.etree as et
 import numpy as np
@@ -178,8 +179,10 @@ class DBNSpec(object):
         """
         with open(filename) as json_data:
             spec = json.load(json_data)
-        b0 = XMLBIFParser.parse(spec['B0'])
-        two_tbn = XMLBIFParser.parse(spec['TBN'])
+            
+        basepath = os.path.dirname(os.path.abspath(filename))
+        b0 = XMLBIFParser.parse(basepath + os.path.sep + spec['B0'])
+        two_tbn = XMLBIFParser.parse(basepath + os.path.sep + spec['TBN'])
         dbn = networks.DynamicBayesianNetwork(b0, two_tbn)
         for transition in spec['transitions']:
             dbn.add_transition(transition[0], transition[1])

--- a/primo2/networks.py
+++ b/primo2/networks.py
@@ -89,7 +89,25 @@ class BayesianNetwork(object):
             Will have to modify all occurances of the old name.
         """
         if oldName in self.node_lookup:
-            pass
+            n = self.node_lookup[oldName]
+            children = list(self.graph.succ[n])
+            for child in children:
+                del child.parents[oldName]
+                child.parents[newName] = n
+                idx = child.parentOrder.index(oldName)
+                child.parentOrder[idx] = newName
+            
+             #Fix nx graph
+            self.graph.remove_node(n)
+            
+            n.name = newName
+            del self.node_lookup[oldName]
+            self.node_lookup[n] = n
+           
+            self.graph.add_node(n)
+            for child in children:
+                self.graph.add_edge(n, self.node_lookup[child])
+            
         else:
             raise Exception("There is no node with name {} in the network.".format(oldName))
 

--- a/primo2/networks.py
+++ b/primo2/networks.py
@@ -91,6 +91,7 @@ class BayesianNetwork(object):
         if oldName in self.node_lookup:
             n = self.node_lookup[oldName]
             children = list(self.graph.succ[n])
+            parents = list(self.graph.pred[n])
             for child in children:
                 del child.parents[oldName]
                 child.parents[newName] = n
@@ -107,6 +108,8 @@ class BayesianNetwork(object):
             self.graph.add_node(n)
             for child in children:
                 self.graph.add_edge(n, self.node_lookup[child])
+            for parent in parents:
+                self.graph.add_edge(self.node_lookup[parent], n)
             
         else:
             raise Exception("There is no node with name {} in the network.".format(oldName))

--- a/primo2/networks.py
+++ b/primo2/networks.py
@@ -69,6 +69,29 @@ class BayesianNetwork(object):
             return self.node_lookup[node_name]
         except KeyError:
             raise Exception("There is no node with name {} in the BayesianNetwork".format(node_name))
+            
+    def change_node_values(self, node, newValues):
+        """
+            Updates the values of the given node. This will invalidate the node
+            and all it's children, as those nodes will expect new CPTs to match
+            the new values!
+        """
+        if node in self.node_lookup:
+            self.node_lookup[node].set_values(newValues)
+            for child in self.graph.succ[node]:
+                child._update_dimensions()
+        else:
+            raise Exception("There is no node with name {} in the network.".format(node))
+            
+    def change_node_name(self, oldName, newName):
+        """
+            Renames the given node to the new name. 
+            Will have to modify all occurances of the old name.
+        """
+        if oldName in self.node_lookup:
+            pass
+        else:
+            raise Exception("There is no node with name {} in the network.".format(oldName))
 
     def get_all_nodes(self):
         return self.graph.nodes()

--- a/primo2/nodes.py
+++ b/primo2/nodes.py
@@ -107,6 +107,26 @@ class DiscreteNode(RandomNode):
         self.parentOrder.append(parentNode.name)
         self._update_dimensions()
         
+    def set_values(self, newValues):
+        """
+            Allows to change/set the values of this variable. This will 
+            invalidate the node, as it is expected to receive a new cpt 
+            matching the new values.
+            
+            Important: This will not update any children of this node, 
+            therefore this method should only be used before specifying 
+            children, or only by the network class which will also invalidate
+            all children of this node!
+            
+            Parameters
+            ----------
+            newValues: [String,]
+                List of the new value names.
+        """
+        self.values = list(newValues)
+        self._update_dimensions()        
+        
+        
     def _update_dimensions(self):
         """
             Private helper function to update the dimensions of the cpd.

--- a/primo2/tests/IO_test.py
+++ b/primo2/tests/IO_test.py
@@ -24,7 +24,7 @@ import unittest
 import numpy as np
 
 from primo2.networks import BayesianNetwork
-from primo2.io import XMLBIFParser
+from primo2.io import XMLBIFParser, DBNSpec
 from primo2.nodes import DiscreteNode
 
 class XMLBIFTest(unittest.TestCase):
@@ -190,6 +190,20 @@ class XMLBIFTest(unittest.TestCase):
         self.assertEqual("Random meta test", alarmNode.meta[1])
         os.remove(testPath)
         
+class DBNSpecTest(unittest.TestCase):
+    
+    def test_parseDBN(self):
+        dbn = DBNSpec.parse("primo2/tests/dbn-test.conf")
+        self.assertEqual(dbn._b0.name, "Test_DBN_B0")
+        self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
+    
+    def test_parseDBN_local_dir(self):
+        os.chdir("primo2/tests")
+        dbn = DBNSpec.parse("dbn-test.conf")
+        self.assertEqual(dbn._b0.name, "Test_DBN_B0")
+        self.assertEqual(dbn._two_tbn.name, "Test_DBN_2TBN")
+        os.chdir("../..")
+    
 if __name__ == "__main__":
     #Workaround so that this script also finds the resource files when run directly
     # from within the tests folder

--- a/primo2/tests/Network_test.py
+++ b/primo2/tests/Network_test.py
@@ -69,9 +69,12 @@ class BayesNetTest(unittest.TestCase):
     def test_change_node_name(self):
         n1 = DiscreteNode("Node1")
         n2 = DiscreteNode("Node2")
+        n3 = DiscreteNode("Node3")
         self.bn.add_node(n1)
         self.bn.add_node(n2)
+        self.bn.add_node(n3)
         self.bn.add_edge(n2,n1)
+        self.bn.add_edge(n3,n2)
         self.bn.change_node_name("Node2", "NewName")
         
         self.assertEqual(n2.name, "NewName")
@@ -83,6 +86,8 @@ class BayesNetTest(unittest.TestCase):
         self.assertTrue(n2 in self.bn.graph.nodes())
         self.assertTrue(n2 in self.bn.node_lookup)
         self.assertTrue(n1 in self.bn.graph.succ[n2])
+        self.assertTrue(n3 in self.bn.graph.pred[n2])
+        self.assertTrue(n2 in self.bn.graph.succ[n3])
         
         
                 

--- a/primo2/tests/Network_test.py
+++ b/primo2/tests/Network_test.py
@@ -21,7 +21,7 @@
 
 import unittest
 from primo2.networks import BayesianNetwork
-from primo2.nodes import RandomNode
+from primo2.nodes import RandomNode, DiscreteNode
 
 class BayesNetTest(unittest.TestCase):
     
@@ -52,6 +52,18 @@ class BayesNetTest(unittest.TestCase):
         self.assertEqual(len(self.bn), 1)
         self.bn.add_node(n2)
         self.assertEqual(len(self.bn), 2)
+        
+    def test_change_node_values_of_parent(self):
+        n1 = DiscreteNode("Node1")
+        n2 = DiscreteNode("Node2")
+        self.bn.add_node(n1)
+        self.bn.add_node(n2)
+        self.bn.add_edge(n2,n1)
+        self.assertEqual(n1.cpd.shape, (2,2))
+        self.bn.change_node_values(n2, ["Value1","Value2","Value3"])
+        self.assertEqual(n2.values, ["Value1","Value2","Value3"])
+        self.assertEqual(n1.valid, False)
+        self.assertEqual(n1.cpd.shape, (2,3))
         
                 
 #    def test_addEdge(self):

--- a/primo2/tests/Network_test.py
+++ b/primo2/tests/Network_test.py
@@ -65,6 +65,23 @@ class BayesNetTest(unittest.TestCase):
         self.assertEqual(n1.valid, False)
         self.assertEqual(n1.cpd.shape, (2,3))
         
+        
+    def test_change_node_name(self):
+        n1 = DiscreteNode("Node1")
+        n2 = DiscreteNode("Node2")
+        self.bn.add_node(n1)
+        self.bn.add_node(n2)
+        self.bn.add_edge(n2,n1)
+        self.bn.change_node_name("Node2", "NewName")
+        
+        self.assertEqual(n2.name, "NewName")
+        with self.assertRaises(Exception) as cm:
+            self.bn.get_node("Node2")
+        self.assertEqual(str(cm.exception), "There is no node with name Node2 in the BayesianNetwork")
+        
+        self.assertEqual(n1.parentOrder, ["NewName"])
+        
+        
                 
 #    def test_addEdge(self):
 #        self.fail("TODO")

--- a/primo2/tests/Network_test.py
+++ b/primo2/tests/Network_test.py
@@ -80,6 +80,9 @@ class BayesNetTest(unittest.TestCase):
         self.assertEqual(str(cm.exception), "There is no node with name Node2 in the BayesianNetwork")
         
         self.assertEqual(n1.parentOrder, ["NewName"])
+        self.assertTrue(n2 in self.bn.graph.nodes())
+        self.assertTrue(n2 in self.bn.node_lookup)
+        self.assertTrue(n1 in self.bn.graph.succ[n2])
         
         
                 

--- a/primo2/tests/Node_test.py
+++ b/primo2/tests/Node_test.py
@@ -106,6 +106,22 @@ class DiscreteNode(unittest.TestCase):
         n.set_cpd(cpd)
         self.assertTrue(n.valid)
         
+    def test_set_values(self):
+        n = nodes.DiscreteNode("Node1")
+        n.set_values(["Value1", "Value2", "Value3"])
+        self.assertEqual(n.cpd.shape, (3,))
+        self.assertEqual(n.values, ["Value1", "Value2", "Value3"])
+        self.assertEqual(n.valid, False)
+        
+    def test_set_values_with_parent(self):
+        n = nodes.DiscreteNode("Node1")
+        n2 = nodes.DiscreteNode("Node2")
+        n.add_parent(n2)
+        n.set_values(["Value1", "Value2", "Value3"])
+        self.assertEqual(n.cpd.shape, (3,2))
+        self.assertEqual(n.values, ["Value1", "Value2", "Value3"])
+        self.assertEqual(n.valid, False)
+        
     def test_add_parent(self):
         n = nodes.DiscreteNode("Node1", ["Value1", "Value2"])
         n2 = nodes.DiscreteNode("Node2", ["Value3", "Value4", "Value5"])


### PR DESCRIPTION
The GUI allows changing the name of nodes (especially when creating new graphs from scratch) which needs to be supported by Primo. As Primo internally uses actual node objects and their names interchangeably, special care needs to be taken when changing a node. This PR hopefully changes all relevant parts on the network side. Any inference structures (especially factor tree!) will obviously have to be recreated after changing a name.