### PR TITLE
Only add edges in factor Tree when node is connected in BN

### DIFF
--- a/primo2/inference/exact.py
+++ b/primo2/inference/exact.py
@@ -435,11 +435,7 @@ class FactorTree(object):
             if neighbor != parent:
                 #Send message out to neighbor
                 newSeqFactor = tree.node[curNode]["factor"].marginalize(tree.node[curNode]["variables"]-tree[curNode][neighbor]["sep"])
-                try:
-                    tree.node[neighbor]["factor"] = tree.node[neighbor]["factor"] * (newSeqFactor / tree[curNode][neighbor]["factor"])
-                except FloatingPointError as e:
-                    print("CurNode: {}, neighbor: {}".format(curNode, neighbor))
-                    raise FloatingPointError(e)
+                tree.node[neighbor]["factor"] = tree.node[neighbor]["factor"] * (newSeqFactor / tree[curNode][neighbor]["factor"])
                 tree[curNode][neighbor]["factor"] = newSeqFactor
                 # Have neighbor pushing out further
                 self.push_messages(tree, neighbor, curNode)

--- a/primo2/inference/exact.py
+++ b/primo2/inference/exact.py
@@ -228,7 +228,6 @@ class FactorTree(object):
             clusterSeq.insert(idx, move)
             clusterSeq.remove(move)
             
-#        print("clusters: ", clusterSeq)
         # Construct jointree
         tree = nx.Graph(messagesValid=False)
         if len(clusterSeq) > 0:
@@ -241,7 +240,6 @@ class FactorTree(object):
                               factor=Factor.get_trivial())
                 jointreeProp = set(clusterSeq[i]).intersection(
                                                 set().union(*clusterSeq[i+1:]))
-#                print("curCluster: {}, joinTreeprop: {}".format(clusterSeq[i], jointreeProp))
                 for cl in clusterSeq[i+1:]:
                     if len(jointreeProp) != 0 and  jointreeProp.issubset(set(cl)):
                         tree.add_edge("".join(clusterSeq[i]), "".join(cl), 
@@ -249,7 +247,6 @@ class FactorTree(object):
                                       factor=Factor.get_trivial())
                         break
                     
-#        print("tree: ", list(tree.neighbors_iter("a")))
                     
         # Assign factors to clusters
         for f in factors:

--- a/primo2/tests/Inverence_test.py
+++ b/primo2/tests/Inverence_test.py
@@ -153,14 +153,18 @@ class FactorEliminationTest(unittest.TestCase):
         self.bn = XMLBIFParser.parse("primo2/tests/slippery.xbif")
         
         
-    def test_trivial_network(self):
+    def test_not_connected_node_without_cpt(self):
 #        bn = BayesianNetwork()
         from primo2.nodes import DiscreteNode
         n = DiscreteNode("a")
         self.bn.add_node(n)
         ft = FactorTree.create_jointree(self.bn)
         ft.set_evidence({"a": "False"})
-        
+        res = ft.marginals(["a"])
+        #Even with evidence set, when we do not have a cpt the result should remain
+        #at 0! Even if only to indicate that something might be wrong with that
+        #node.
+        np.testing.assert_array_almost_equal(res.get_potential(), np.array([0.0, 0.0])) 
         
     def test_empty_cpt(self):
         bn = BayesianNetwork()

--- a/primo2/tests/Inverence_test.py
+++ b/primo2/tests/Inverence_test.py
@@ -153,6 +153,15 @@ class FactorEliminationTest(unittest.TestCase):
         self.bn = XMLBIFParser.parse("primo2/tests/slippery.xbif")
         
         
+    def test_trivial_network(self):
+#        bn = BayesianNetwork()
+        from primo2.nodes import DiscreteNode
+        n = DiscreteNode("a")
+        self.bn.add_node(n)
+        ft = FactorTree.create_jointree(self.bn)
+        ft.set_evidence({"a": "False"})
+        
+        
     def test_empty_cpt(self):
         bn = BayesianNetwork()
         from primo2.nodes import DiscreteNode


### PR DESCRIPTION
This PR fixes a small error that nodes that have not been connected in the BN (therefore useless nodes) where still connected to the resulting factortree. While this did not really cause an issue when that node contained a valid CPT, it did cause a ```FloatingPointError: divide by zero encountered in true_divide``` error, when the CPT of the unconnected node was not set upon setting evidence/message passing.

Fixes #21 
